### PR TITLE
Make camera2D current

### DIFF
--- a/default_scene.tscn
+++ b/default_scene.tscn
@@ -8,3 +8,4 @@
 texture = ExtResource( 1 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
+current = true


### PR DESCRIPTION
This will correctly show the sprite at the centre and not make it look like something is wrong with the game/build.